### PR TITLE
Add Pydantic runtime dependency and clean up registry/OpenAI modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 dependencies = [
     "google-genai",
-    "openai"
+    "openai",
+    "pydantic>=2.0"
 ]
 
 [project.urls]

--- a/src/llm_core/README.md
+++ b/src/llm_core/README.md
@@ -70,7 +70,7 @@ Tools require type hints with `Annotated` and `Field` descriptions to generate p
 ```python
 from typing import Annotated
 from pydantic import Field
-from src.llm_core.registry import ToolRegistry
+from llm_core.registry import ToolRegistry
 
 # Assuming a concrete implementation of ToolRegistry exists
 registry = MyProviderRegistry()
@@ -89,7 +89,7 @@ def get_weather(
 To add a new LLM provider, subclass `GenericLLM` and implement the abstract methods.
 
 ```python
-from src.llm_core.base import GenericLLM
+from llm_core.base import GenericLLM
 
 class MyLLM(GenericLLM):
     async def chat(self, history, user_prompt):

--- a/src/llm_core/registry.py
+++ b/src/llm_core/registry.py
@@ -4,20 +4,11 @@ from typing import Callable, Dict, Any, Union, Optional, get_origin, Annotated, 
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from pydantic import create_model # NOTE: For context: it was pydantic.v1 before.
+from pydantic import create_model  # NOTE: For context: it was pydantic.v1 before.
 
 from .types import ToolDefinition
 from .exceptions import ToolRegistrationError, ToolValidationError
 import inspect
-
-TYPE_MAPPING = {
-    str: "STRING",
-    int: "INTEGER",
-    float: "NUMBER",
-    bool: "BOOLEAN",
-    list: "ARRAY",
-    dict: "OBJECT"
-}
 
 class ToolRegistry(ABC):
     """
@@ -126,7 +117,7 @@ class ToolRegistry(ABC):
         )
 
     def tool(self, func: Callable) -> Callable:
-        """A decorator to turn a function into a Gemini tool"""
+        """A decorator to turn a function into an LLM tool."""
         self.register(func)
         return func
 

--- a/src/llm_impl/gemini/registry.py
+++ b/src/llm_impl/gemini/registry.py
@@ -1,18 +1,6 @@
-import inspect
-
 from google.genai import types
 from llm_core import ToolRegistry, ToolDefinition
-from llm_core.exceptions import ToolRegistrationError
 from typing import Callable, Dict, Any, Union, Optional
-
-TYPE_MAPPING = {
-    str: "STRING",
-    int: "INTEGER",
-    float: "NUMBER",
-    bool: "BOOLEAN",
-    list: "ARRAY",
-    dict: "OBJECT"
-}
 
 class GeminiToolRegistry(ToolRegistry):
     """

--- a/src/llm_impl/open_api/core.py
+++ b/src/llm_impl/open_api/core.py
@@ -1,15 +1,10 @@
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
 from typing import List, Tuple, Optional, Any, Dict
-import inspect
-import json
-import asyncio
 import logging
 from llm_core import GenericLLM, ToolRegistry
 from .models import OpenAIMessageResponse, OpenAIChatResponse, OpenAITokens
 from .tool_helper import ToolHelper
-
-import pprint
 
 logger = logging.getLogger(__name__)
 

--- a/src/llm_impl/open_api/registry.py
+++ b/src/llm_impl/open_api/registry.py
@@ -1,16 +1,5 @@
-import inspect
 from llm_core import ToolRegistry, ToolDefinition
-from llm_core.exceptions import ToolRegistrationError
 from typing import Callable, Dict, Any, Union, Optional, List
-
-TYPE_MAPPING = {
-    str: "string",
-    int: "integer",
-    float: "number",
-    bool: "boolean",
-    list: "array",
-    dict: "object"
-}
 
 class OpenAIToolRegistry(ToolRegistry):
     """


### PR DESCRIPTION
### Motivation
- Ensure the package declares the `pydantic` runtime dependency because the core registry uses Pydantic models and schema generation.  
- Remove unused imports and dead `TYPE_MAPPING` constants to reduce noise and potential static-analysis/type-checker warnings.  
- Fix README import examples to use the installed package import paths so examples work when the package is installed.

### Description
- Added `pydantic>=2.0` to `pyproject.toml` dependencies.  
- Cleaned up `src/llm_core/registry.py` by normalizing `pydantic` imports, removing the unused `TYPE_MAPPING`, and clarifying the `tool` decorator docstring.  
- Removed unused imports from `src/llm_impl/gemini/registry.py` and `src/llm_impl/open_api/registry.py`, and removed unused `inspect`, `json`, `asyncio`, and `pprint` imports from `src/llm_impl/open_api/core.py`.  
- Updated `src/llm_core/README.md` examples to import `ToolRegistry` and `GenericLLM` from `llm_core` package paths instead of `src.llm_core`.

### Testing
- No automated tests were executed as part of this change (no test run requested).  
- Changes are limited to dependency metadata, import cleanup, docstring/text edits, and should be safe, but recommend running `pytest` and a linter/type-checker in CI to validate the runtime integration with `pydantic>=2.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca646d91c832cab32c7ae4cf3cec6)