### PR TITLE
refactor(core): centralize tool execution loop

### DIFF
--- a/src/llm_core/tool_loop.py
+++ b/src/llm_core/tool_loop.py
@@ -1,0 +1,213 @@
+"""Shared tool execution loop utilities for LLM implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Optional, Sequence
+
+from .exceptions import ToolExecutionError
+from .registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToolCallRequest:
+    """Represents a normalized tool call request from an LLM response."""
+
+    name: str
+    arguments: Any
+    call_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ToolCallResult:
+    """Represents the outcome of executing a tool call."""
+
+    name: str
+    response: Dict[str, Any]
+    call_id: Optional[str] = None
+
+
+class ToolExecutionLoop:
+    """Centralized tool execution loop for LLM providers.
+
+    This loop handles argument normalization, validation, tool execution,
+    and error handling in a provider-agnostic way.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: Optional[ToolRegistry],
+        max_function_loops: int,
+        tool_timeout: float = 60.0,
+        argument_error_formatter: Optional[Callable[[str, Exception], str]] = None,
+    ) -> None:
+        """Initialize the tool execution loop.
+
+        Args:
+            registry: Tool registry used to resolve tool definitions.
+            max_function_loops: Maximum number of tool-call iterations allowed.
+            tool_timeout: Timeout in seconds for tool execution.
+            argument_error_formatter: Optional formatter for argument parsing errors.
+        """
+
+        self._registry = registry
+        self._max_function_loops = max_function_loops
+        self._tool_timeout = tool_timeout
+        self._argument_error_formatter = argument_error_formatter or self._default_argument_error
+
+    async def run(
+        self,
+        *,
+        initial_response: Any,
+        get_tool_calls: Callable[[Any], Sequence[ToolCallRequest]],
+        record_assistant_message: Callable[[Any], None],
+        build_tool_response_message: Callable[[ToolCallResult], Any],
+        send_tool_responses: Callable[[Sequence[Any]], Awaitable[Any]],
+    ) -> Any:
+        """Run the tool execution loop.
+
+        Args:
+            initial_response: Initial provider response to inspect.
+            get_tool_calls: Extracts tool calls from a provider response.
+            record_assistant_message: Persists the assistant response in provider history.
+            build_tool_response_message: Builds a provider message from tool results.
+            send_tool_responses: Sends tool results back to the provider to get a new response.
+
+        Returns:
+            The final provider response after tool execution completes.
+        """
+
+        current_response = initial_response
+
+        for _ in range(self._max_function_loops):
+            tool_calls = list(get_tool_calls(current_response))
+
+            if not tool_calls:
+                record_assistant_message(current_response)
+                return current_response
+
+            record_assistant_message(current_response)
+
+            response_messages = []
+            for tool_call in tool_calls:
+                result = await self._handle_tool_call(tool_call)
+                response_messages.append(build_tool_response_message(result))
+
+            if response_messages:
+                current_response = await send_tool_responses(response_messages)
+            else:
+                return current_response
+
+        return current_response
+
+    async def _handle_tool_call(self, tool_call: ToolCallRequest) -> ToolCallResult:
+        if not self._registry or tool_call.name not in self._registry.tools:
+            msg = f"Tool '{tool_call.name}' not found in registry."
+            return ToolCallResult(
+                name=tool_call.name,
+                response={"error": msg},
+                call_id=tool_call.call_id,
+            )
+
+        tool_def = self._registry.tools[tool_call.name]
+
+        try:
+            function_args = self._normalize_function_args(tool_call.name, tool_call.arguments)
+        except ToolExecutionError as exc:
+            msg = str(exc)
+            logger.warning("ToolExecutionError in '%s': %s", tool_call.name, msg)
+            return ToolCallResult(
+                name=tool_call.name,
+                response={"error": msg},
+                call_id=tool_call.call_id,
+            )
+
+        if tool_def.args_model:
+            try:
+                validated_args = tool_def.args_model(**function_args)
+                function_args = validated_args.model_dump()
+            except Exception as validation_error:
+                msg = f"Argument validation failed: {validation_error}"
+                logger.warning("ToolExecutionError in '%s': %s", tool_call.name, msg)
+                return ToolCallResult(
+                    name=tool_call.name,
+                    response={"error": msg},
+                    call_id=tool_call.call_id,
+                )
+
+        try:
+            function_result = await self._execute_tool(tool_def.func, function_args)
+        except ToolExecutionError as exc:
+            msg = str(exc)
+            logger.warning("ToolExecutionError in '%s': %s", tool_call.name, msg)
+            return ToolCallResult(
+                name=tool_call.name,
+                response={"error": msg},
+                call_id=tool_call.call_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "Unexpected error executing tool '%s': %s",
+                tool_call.name,
+                exc,
+                exc_info=True,
+            )
+            msg = "An internal error occurred during tool execution."
+            return ToolCallResult(
+                name=tool_call.name,
+                response={"error": msg},
+                call_id=tool_call.call_id,
+            )
+
+        return ToolCallResult(
+            name=tool_call.name,
+            response={"result": function_result},
+            call_id=tool_call.call_id,
+        )
+
+    def _normalize_function_args(self, tool_name: str, raw_args: Any) -> Dict[str, Any]:
+        if raw_args is None or raw_args == "":
+            return {}
+        if isinstance(raw_args, dict):
+            return raw_args
+        if isinstance(raw_args, str):
+            try:
+                parsed = json.loads(raw_args)
+            except json.JSONDecodeError as exc:
+                raise ToolExecutionError(self._argument_error_formatter(tool_name, exc)) from exc
+            if parsed is None:
+                return {}
+            if not isinstance(parsed, dict):
+                msg = ValueError("Function arguments must decode to a JSON object.")
+                raise ToolExecutionError(self._argument_error_formatter(tool_name, msg))
+            return parsed
+        try:
+            return dict(raw_args)
+        except (TypeError, ValueError) as exc:
+            raise ToolExecutionError(self._argument_error_formatter(tool_name, exc)) from exc
+
+    async def _execute_tool(self, tool_function: Any, function_args: Dict[str, Any]) -> Any:
+        try:
+            if inspect.iscoroutinefunction(tool_function):
+                return await asyncio.wait_for(
+                    tool_function(**function_args),
+                    timeout=self._tool_timeout,
+                )
+            return await asyncio.wait_for(
+                asyncio.to_thread(tool_function, **function_args),
+                timeout=self._tool_timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            msg = f"Tool execution timed out after {self._tool_timeout} seconds."
+            raise ToolExecutionError(msg) from exc
+
+    @staticmethod
+    def _default_argument_error(tool_name: str, error: Exception) -> str:
+        return f"Failed to parse arguments for tool '{tool_name}': {error}"

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import AsyncMock
+from pydantic import BaseModel
+
+from llm_core.tool_loop import ToolExecutionLoop, ToolCallRequest, ToolCallResult
+from llm_impl.open_api.registry import OpenAIToolRegistry
+from llm_core.types import ToolDefinition
+
+
+class SampleArgs(BaseModel):
+    required_value: int
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_loop_runs_tools():
+    registry = OpenAIToolRegistry()
+    tool_func = AsyncMock(return_value="ok")
+    registry.tools["sample"] = ToolDefinition(
+        name="sample",
+        description="sample tool",
+        func=tool_func,
+    )
+
+    loop = ToolExecutionLoop(
+        registry=registry,
+        max_function_loops=2,
+    )
+
+    initial_response = {"tool_calls": [ToolCallRequest(name="sample", arguments={"a": 1})]}
+    final_response = {"tool_calls": []}
+    recorded = []
+    captured_tool_results = []
+
+    def get_tool_calls(response):
+        return response["tool_calls"]
+
+    def record_assistant_message(response):
+        recorded.append(response)
+
+    def build_tool_response_message(tool_result: ToolCallResult):
+        captured_tool_results.append(tool_result)
+        return tool_result
+
+    async def send_tool_responses(tool_messages):
+        return final_response
+
+    response = await loop.run(
+        initial_response=initial_response,
+        get_tool_calls=get_tool_calls,
+        record_assistant_message=record_assistant_message,
+        build_tool_response_message=build_tool_response_message,
+        send_tool_responses=send_tool_responses,
+    )
+
+    tool_func.assert_called_once_with(a=1)
+    assert response == final_response
+    assert recorded == [initial_response]
+    assert captured_tool_results[0].response == {"result": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_loop_handles_invalid_arguments():
+    registry = OpenAIToolRegistry()
+
+    async def tool_func(required_value: int) -> int:
+        return required_value
+
+    registry.tools["validated"] = ToolDefinition(
+        name="validated",
+        description="validated tool",
+        func=tool_func,
+        args_model=SampleArgs,
+    )
+
+    loop = ToolExecutionLoop(
+        registry=registry,
+        max_function_loops=1,
+    )
+
+    initial_response = {"tool_calls": [ToolCallRequest(name="validated", arguments={"required_value": "bad"})]}
+    recorded = []
+    tool_results = []
+
+    def get_tool_calls(response):
+        return response["tool_calls"]
+
+    def record_assistant_message(response):
+        recorded.append(response)
+
+    def build_tool_response_message(tool_result: ToolCallResult):
+        tool_results.append(tool_result)
+        return tool_result
+
+    async def send_tool_responses(tool_messages):
+        return {"tool_calls": []}
+
+    await loop.run(
+        initial_response=initial_response,
+        get_tool_calls=get_tool_calls,
+        record_assistant_message=record_assistant_message,
+        build_tool_response_message=build_tool_response_message,
+        send_tool_responses=send_tool_responses,
+    )
+
+    assert tool_results
+    error_message = tool_results[0].response["error"]
+    assert "Argument validation failed:" in error_message
+    assert "required_value" in error_message


### PR DESCRIPTION
### Motivation

- Remove duplicated function-calling loop logic that existed in the OpenAI and Gemini implementations so fixes and behavior live in one place.
- Provide a single, provider-agnostic path for argument normalization, validation, execution, timeout and error handling to avoid divergent behavior across adapters.
- Reduce maintenance burden and prevent regressions (e.g. previously observed blocking-loop fixes had to be applied in two places).

### Description

- Add `src/llm_core/tool_loop.py` implementing `ToolExecutionLoop`, `ToolCallRequest`, and `ToolCallResult` to centralize argument parsing, validation, timeouts, execution, and error mapping.
- Update `src/llm_impl/open_api/tool_helper.py` to delegate function-calling to `ToolExecutionLoop` and adapt OpenAI-specific message mapping and error formatting.
- Update `src/llm_impl/gemini/core.py` to use `ToolExecutionLoop` and provide adapter functions to convert Gemini `parts`/`function_call` objects to/from the shared loop structures.
- Add unit tests `tests/test_tool_loop.py` exercising normal tool execution and argument validation/error handling behavior.

### Testing

- Added `tests/test_tool_loop.py` and attempted to run `uv run pytest tests/test_tool_helper.py tests/test_gemini_core.py tests/test_tool_loop.py` to validate integration with the existing provider tests.
- The test run could not complete in this environment because dependency installation failed due to network restrictions (failed to fetch `pydantic`), so the full suite could not be executed here.
- AI assistance disclaimer: this change was prepared with the help of an AI coding assistant; reviewers should focus on provider adapter mappings and error-message consistency when validating behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cd71e9ab8832ca7968f62eaab1b92)